### PR TITLE
close body when sending to slack

### DIFF
--- a/src/cred-alert/notifications/slack_notifier.go
+++ b/src/cred-alert/notifications/slack_notifier.go
@@ -118,6 +118,8 @@ func (n *slackNotifier) makeSingleAttempt(logger lager.Logger, currentAttempt in
 		return false, err
 	}
 
+	defer resp.Body.Close()
+
 	switch resp.StatusCode {
 	case http.StatusOK:
 		return false, nil

--- a/src/cred-alert/notifications/slack_notifier_test.go
+++ b/src/cred-alert/notifications/slack_notifier_test.go
@@ -1,7 +1,9 @@
 package notifications_test
 
 import (
+	"bytes"
 	"errors"
+	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -344,6 +346,7 @@ var _ = Describe("Slack Notifier", func() {
 					if fakeHTTPClient.DoCallCount() > 2 {
 						return &http.Response{
 							StatusCode: http.StatusOK,
+							Body:       ioutil.NopCloser(&bytes.Buffer{}),
 						}, nil
 					}
 


### PR DESCRIPTION
I think this will cut down on the number of open file descriptor limit
errors we're seeing.